### PR TITLE
Add lesson links to calendar

### DIFF
--- a/bookmark_template.html
+++ b/bookmark_template.html
@@ -138,6 +138,12 @@
       margin-top: 4px;
     }
 
+    .study-link {
+      text-decoration: none;
+      color: inherit;
+      display: block;
+    }
+
     .shabbat {
       background: var(--shabbat-bg) !important;
       color: var(--shabbat-text) !important;
@@ -197,7 +203,13 @@
                     <div class="label">{{ day.label }}</div>
                   {% endif %}
                   {% if day.study_portion %}
-                    <div class="study">{{ day.study_portion }}</div>
+                    {% if day.link %}
+                      <a href="{{ day.link }}" class="study-link">
+                        <div class="study">{{ day.study_portion }}</div>
+                      </a>
+                    {% else %}
+                      <div class="study">{{ day.study_portion }}</div>
+                    {% endif %}
                   {% else %}
                     &nbsp;
                   {% endif %}


### PR DESCRIPTION
## Summary
- add Sefaria search link template for daily lessons
- insert daily description query into ICS event and HTML calendar links
- document `link_template` variables in docstrings

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685308853388832590c310b73797ec98