### PR TITLE
Enable custom alarm times

### DIFF
--- a/app_gui_full_updated.py
+++ b/app_gui_full_updated.py
@@ -61,8 +61,8 @@ class TorahTreeApp(ctk.CTk):
         # משתנה לבחירת מצב הלוח: 0 = חלוקה לפי טווח תאריכים, 1 = לפי הספק יומי קבוע
         self.schedule_mode_var = tk.IntVar(value=0)  # 0 = עד תאריך, 1 = הספק יומי
 
-        # הגדרת זמן התראה ב-ICS ומסגרת ההגדרות הצדדית
-        self.alarm_minutes_before = tk.IntVar(value=30)
+        # הגדרת שעת התראה בקובצי ICS
+        self.alarm_time_str = tk.StringVar(value="08:00")
         self.settings_window = None
 
         days_of_week = ["ראשון", "שני", "שלישי", "רביעי", "חמישי", "שישי", "שבת"]
@@ -283,8 +283,8 @@ class TorahTreeApp(ctk.CTk):
         self.settings_window = ctk.CTkFrame(self, fg_color="white", width=800)
         self.settings_window.place(relx=1.0, y=0, relheight=1.0, anchor="ne")
 
-        ctk.CTkLabel(self.settings_window, text="התרעה לפני שיעור (בדקות):").pack(pady=(10,0))
-        ctk.CTkEntry(self.settings_window, textvariable=self.alarm_minutes_before).pack(fill="x", padx=10, pady=6)
+        ctk.CTkLabel(self.settings_window, text="שעת התראה (HH:MM):").pack(pady=(10,0))
+        ctk.CTkEntry(self.settings_window, textvariable=self.alarm_time_str).pack(fill="x", padx=10, pady=6)
         ctk.CTkButton(self.settings_window, text="סגור", command=self.toggle_settings_panel).pack(pady=(5,10))
 
     def choose_file(self):
@@ -608,7 +608,7 @@ class TorahTreeApp(ctk.CTk):
                 tree_data=self.data,
                 no_study_weekdays_set=no_study_weekdays_set,
                 units_per_day=self.units_per_day_var.get() if self.schedule_mode_var.get() == 1 else None,
-                alarm_minutes_before=self.alarm_minutes_before.get() if self.alarm_minutes_before.get() > 0 else None
+                alarm_time=self.alarm_time_str.get() if self.alarm_time_str.get() else None
             )
             messagebox.showinfo("הצלחה", f"הקובץ נשמר:\n{saved_path}")
         except Exception as e:

--- a/tests/test_torah_tree.py
+++ b/tests/test_torah_tree.py
@@ -33,8 +33,11 @@ def load_module():
         ics = types.ModuleType('ics')
         ics.Calendar = type('Calendar', (), {})
         ics.Event = type('Event', (), {})
-        ics.DisplayAlarm = type('DisplayAlarm', (), {})
+        alarm_module = types.ModuleType('ics.alarm')
+        alarm_module.DisplayAlarm = type('DisplayAlarm', (), {})
+        ics.alarm = alarm_module
         sys.modules['ics'] = ics
+        sys.modules['ics.alarm'] = alarm_module
 
     if 'tkinter' not in sys.modules:
         tk = types.ModuleType('tkinter')

--- a/torah_logic_full_updated.py
+++ b/torah_logic_full_updated.py
@@ -915,18 +915,23 @@ def write_ics_file(
         link = link_template.format(ref=quote(ref, safe='.-_%')) if ref else ""
         e = Event()
         e.name = event_base_name
-        e.begin = day_data['date'].strftime('%Y-%m-%d')
-        e.make_all_day()
-        e.description = day_data['description'] + (f"\n{link}" if link else "")
-        if link:
-            e.url = link
+        start_str = day_data['date'].strftime('%Y-%m-%d')
+        alarm_dt = None
         if alarm_time:
             try:
                 alarm_t = datetime.strptime(alarm_time, "%H:%M").time()
                 alarm_dt = datetime.combine(day_data['date'], alarm_t)
-                e.alarms.append(DisplayAlarm(trigger=alarm_dt))
+                start_str = alarm_dt
             except ValueError:
                 pass
+        e.begin = start_str
+        if not alarm_time:
+            e.make_all_day()
+        e.description = day_data['description'] + (f"\n{link}" if link else "")
+        if link:
+            e.url = link
+        if alarm_dt:
+            e.alarms.append(DisplayAlarm(trigger=alarm_dt))
         cal.events.add(e)
 
     # יצירת שם קובץ חכם


### PR DESCRIPTION
## Summary
- support specifying the alarm time for daily events in `write_ics_file`
- expose new field in the GUI for alarm time instead of minutes before
- adjust example usage
- update tests to stub new import path

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68598e0e59e48325af6c2ec79b2beaa5