### PR TITLE
Add Hebrew calendar input support

### DIFF
--- a/app_gui_full_updated.py
+++ b/app_gui_full_updated.py
@@ -286,9 +286,6 @@ class TorahTreeApp(ctk.CTk):
         self.end_date_label.pack(anchor="w", padx=10, pady=(5,0))
         self.end_date_entry = None
 
-        # יצירת שדות תאריך בהתאם להגדרות
-        self._build_date_widgets()
-
         # הספק יומי (יופיע רק במצב הספק יומי)
         self.units_per_day_label = ttk.Label(schedule_frame, text="הספק יומי (יחידות):", font=("Arial", 15))
         self.units_per_day_label.pack(anchor="w", padx=10, pady=(5,0))
@@ -300,6 +297,9 @@ class TorahTreeApp(ctk.CTk):
             font=ctk.CTkFont(size=14)
         )
         self.units_per_day_entry.pack(fill="x", padx=10, pady=(0,5))
+
+        # יצירת שדות תאריך בהתאם להגדרות כעת שהווידג'טים הנדרשים קיימים
+        self._build_date_widgets()
 
         # מסגרת לבחירת ימי חופשה שבועיים
         no_study_frame = ctk.CTkFrame(ctrl_frame, fg_color="#d9e9f6", corner_radius=12)


### PR DESCRIPTION
## Summary
- add `HebrewDateEntry` widget wrapping `tkcalendar.Calendar`
- allow `parse_date` to read Hebrew dates via `pyluach`
- use Hebrew date entry fields in the main GUI

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685be38e4f6083258165cd6f79c8f3a6