### PR TITLE
Use webbrowser when opening generated HTML

### DIFF
--- a/app_gui_full_updated.py
+++ b/app_gui_full_updated.py
@@ -9,6 +9,7 @@ from datetime import date, timedelta, datetime
 import math
 import locale
 import os
+import webbrowser
 from pyluach import dates, hebrewcal
 
 # ייבוא פונקציות לוגיות מהמודול הנפרד
@@ -1007,7 +1008,7 @@ class TorahTreeApp(ctk.CTk):
                 skip_holidays=self.skip_holidays_var.get()
             )
             messagebox.showinfo("הצלחה", f"הקובץ HTML נשמר:\n{saved_path}")
-            os.startfile(saved_path) # פתיחת הקובץ בדפדפן ברירת המחדל
+            webbrowser.open(saved_path)  # פתיחת הקובץ בדפדפן ברירת המחדל
         except Exception as e:
             messagebox.showerror("שגיאה", str(e))
 


### PR DESCRIPTION
## Summary
- import `webbrowser` in the GUI
- open exported HTML using `webbrowser.open`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68697fa8400483258601c3c89213c0bd