### PR TITLE
Add simple web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,15 @@
    ```bash
    pip install -r requirements.txt
    ```
-2. הריצו את התוכנה:
+2. הריצו את התוכנה המלאה עם הממשק הגרפי הקיים:
    ```bash
    python app_gui_full_updated.py
    ```
+3. להפעלת הממשק הדפדפני החדש:
+   ```bash
+   python web_app/app.py
+   ```
+   ואז לפתוח את `http://localhost:5000` בדפדפן.
 
 ## תפעול כללי
 1. בחרו פריטים מעץ הלימוד המוצג במסך הראשי.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyluach
 jinja2
 customtkinter
 tkcalendar
+flask

--- a/web_app/app.py
+++ b/web_app/app.py
@@ -1,0 +1,69 @@
+import os
+from datetime import date
+from flask import Flask, render_template, request, send_file, flash
+
+from torah_logic_full_updated import (
+    load_data,
+    write_bookmark_html,
+    write_ics_file,
+)
+
+app = Flask(__name__)
+app.config['SECRET_KEY'] = 'hspek-secret'
+
+DATA_PATH = os.path.join(os.path.dirname(__file__), '..', 'torah_tree_data_full.json')
+TREE_DATA = load_data(DATA_PATH)
+
+@app.route('/', methods=['GET', 'POST'])
+def index():
+    if request.method == 'POST':
+        try:
+            titles = [t.strip() for t in request.form.get('titles', '').splitlines() if t.strip()]
+            mode = request.form['mode']
+            start_date = date.fromisoformat(request.form['start_date'])
+            end_date = date.fromisoformat(request.form['end_date'])
+            schedule_mode = request.form.get('schedule_mode', 'range')
+            units_per_day = int(request.form.get('units_per_day', 1)) if schedule_mode == 'daily' else None
+            skip_holidays = request.form.get('skip_holidays') == 'on'
+            balance = request.form.get('balance_mishnayot') == 'on'
+            output_format = request.form.get('output_format', 'html')
+
+            no_study_days = set()
+
+            if output_format == 'html':
+                path = write_bookmark_html(
+                    titles_list=titles,
+                    mode=mode,
+                    start_date=start_date,
+                    end_date=end_date,
+                    tree_data=TREE_DATA,
+                    no_study_weekdays_set=no_study_days,
+                    units_per_day=units_per_day,
+                    skip_holidays=skip_holidays,
+                    balance_chapters_by_mishnayot=balance,
+                )
+            else:
+                path = write_ics_file(
+                    titles_list=titles,
+                    mode=mode,
+                    start_date=start_date,
+                    end_date=end_date,
+                    tree_data=TREE_DATA,
+                    no_study_weekdays_set=no_study_days,
+                    units_per_day=units_per_day,
+                    skip_holidays=skip_holidays,
+                    alarm_time=None,
+                    balance_chapters_by_mishnayot=balance,
+                )
+
+            if path:
+                return send_file(path, as_attachment=True)
+            else:
+                flash('לא נוצר קובץ.')
+        except Exception as e:
+            flash(str(e))
+
+    return render_template('index.html')
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/web_app/static/styles.css
+++ b/web_app/static/styles.css
@@ -1,0 +1,13 @@
+body {
+  font-family: sans-serif;
+  direction: rtl;
+  text-align: right;
+  margin: 2em;
+}
+label {
+  display: block;
+  margin-top: 10px;
+}
+.messages {
+  color: red;
+}

--- a/web_app/templates/index.html
+++ b/web_app/templates/index.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+  <meta charset="utf-8">
+  <title>Hspek Web</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
+</head>
+<body>
+  <h1>Hspek Web</h1>
+  {% with messages = get_flashed_messages() %}
+  {% if messages %}
+    <ul class="messages">
+    {% for m in messages %}
+      <li>{{ m }}</li>
+    {% endfor %}
+    </ul>
+  {% endif %}
+  {% endwith %}
+  <form method="post">
+    <label for="titles">רשימת כותרים (שורה לכל פריט):</label>
+    <textarea id="titles" name="titles" rows="4" cols="40">{{ request.form.get('titles','') }}</textarea>
+
+    <label for="mode">סוג ספירה:</label>
+    <select id="mode" name="mode">
+      {% for opt in ['פרקים','משניות','דפים','עמודים'] %}
+      <option value="{{ opt }}" {% if request.form.get('mode') == opt %}selected{% endif %}>{{ opt }}</option>
+      {% endfor %}
+    </select>
+
+    <label for="start_date">תאריך התחלה:</label>
+    <input type="date" id="start_date" name="start_date" value="{{ request.form.get('start_date','') }}">
+
+    <label for="end_date">תאריך סיום:</label>
+    <input type="date" id="end_date" name="end_date" value="{{ request.form.get('end_date','') }}">
+
+    <fieldset>
+      <legend>מצב לוח</legend>
+      <label><input type="radio" name="schedule_mode" value="range" {% if request.form.get('schedule_mode','range') == 'range' %}checked{% endif %}>עד תאריך</label>
+      <label><input type="radio" name="schedule_mode" value="daily" {% if request.form.get('schedule_mode') == 'daily' %}checked{% endif %}>הספק יומי</label>
+    </fieldset>
+
+    <label for="units_per_day">הספק יומי:</label>
+    <input type="number" id="units_per_day" name="units_per_day" min="1" value="{{ request.form.get('units_per_day','1') }}">
+
+    <label><input type="checkbox" name="skip_holidays" {% if request.form.get('skip_holidays') %}checked{% endif %}>דלג על חגים</label>
+    <label><input type="checkbox" name="balance_mishnayot" {% if request.form.get('balance_mishnayot') %}checked{% endif %}>איזון פרקי משנה</label>
+
+    <label for="output_format">פורמט פלט:</label>
+    <select id="output_format" name="output_format">
+      <option value="html" {% if request.form.get('output_format') == 'html' %}selected{% endif %}>HTML</option>
+      <option value="ics" {% if request.form.get('output_format') == 'ics' %}selected{% endif %}>ICS</option>
+    </select>
+
+    <button type="submit">צור קובץ</button>
+  </form>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add Flask dependency
- create `web_app/` with a basic Flask server
- expose simple HTML form for generating study files
- document the browser interface in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68740083fdc883258be5d7090a53aca8