### PR TITLE
Fix resource_path import and packaging

### DIFF
--- a/app_gui_full_updated.py
+++ b/app_gui_full_updated.py
@@ -11,6 +11,13 @@ import locale
 import os
 import sys
 import webbrowser
+
+try:
+    from utils import resource_path
+except ModuleNotFoundError:  # allows running without the utils module on PATH
+    def resource_path(filename: str) -> str:
+        base = getattr(sys, "_MEIPASS", os.path.abspath("."))
+        return os.path.join(base, filename)
 from pyluach import dates, hebrewcal
 
 # ייבוא פונקציות לוגיות מהמודול הנפרד
@@ -35,13 +42,8 @@ except locale.Error:
 ctk.set_appearance_mode("system")  # הגדרת ערכת נושא בהתאם למערכת
 ctk.set_default_color_theme("blue") # הגדרת צבע ברירת מחדל
 
-DEFAULT_FILE = "torah_tree_data_full.json" # קובץ נתונים ברירת מחדל
 
-def resource_path(filename):
-    """החזרת נתיב לקובץ – עובד גם בפיתוח וגם בתוך EXE"""
-    if hasattr(sys, '_MEIPASS'):
-        return os.path.join(sys._MEIPASS, filename)
-    return os.path.join(os.path.abspath("."), filename)
+DEFAULT_FILE = "torah_tree_data_full.json"  # קובץ נתונים ברירת מחדל
 
 # ==============================================================================
 #                                 מחלקת האפליקציה הראשית

--- a/torah_logic_full_updated.py
+++ b/torah_logic_full_updated.py
@@ -10,15 +10,16 @@ from pyluach import dates, hebrewcal, parshios
 from jinja2 import Environment, FileSystemLoader
 from collections import defaultdict
 
+try:
+    from utils import resource_path
+except ModuleNotFoundError:  # falls back when running as a standalone file
+    def resource_path(filename: str) -> str:
+        base = getattr(sys, "_MEIPASS", os.path.abspath("."))
+        return os.path.join(base, filename)
+
 # כתובת ברירת מחדל לפתיחת חומר הלימוד היומי
 # {ref} מוחלף בהפניה המדויקת בספריא (לדוגמה "בראשית.א-ב")
 DEFAULT_LESSON_LINK = "https://www.sefaria.org.il/he/{ref}"
-
-def resource_path(filename):
-    """החזרת נתיב לקובץ – עובד גם בפיתוח וגם בתוך EXE"""
-    if hasattr(sys, '_MEIPASS'):
-        return os.path.join(sys._MEIPASS, filename)
-    return os.path.join(os.path.abspath("."), filename)
 
 
 # זיהוי קטגוריית התוכן (תנ"ך, משנה או תלמוד) לפי הנתיב המלא של היחידה

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,14 @@
+import os
+import sys
+
+
+def resource_path(filename: str) -> str:
+    """Return path to a bundled resource.
+
+    When running as a PyInstaller bundle the files are unpacked to a
+    temporary directory accessible via ``sys._MEIPASS``. This helper
+    ensures resources are located correctly both when running from source
+    and from the packaged executable.
+    """
+    base = getattr(sys, "_MEIPASS", os.path.abspath("."))
+    return os.path.join(base, filename)


### PR DESCRIPTION
## Summary
- move resource_path helper to new utils module
- import resource_path with fallback for standalone use
- ensure GUI and logic access shared helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6876d0a98ffc83258b50ab79bea5f025