### PR TITLE
Refactor resource path helper

### DIFF
--- a/app_gui_full_updated.py
+++ b/app_gui_full_updated.py
@@ -9,9 +9,9 @@ from datetime import date, timedelta, datetime
 import math
 import locale
 import os
-import sys
 import webbrowser
 from pyluach import dates, hebrewcal
+from hspek.utils.paths import resource_path
 
 # ייבוא פונקציות לוגיות מהמודול הנפרד
 from torah_logic_full_updated import (
@@ -36,12 +36,6 @@ ctk.set_appearance_mode("system")  # הגדרת ערכת נושא בהתאם ל�
 ctk.set_default_color_theme("blue") # הגדרת צבע ברירת מחדל
 
 DEFAULT_FILE = "torah_tree_data_full.json" # קובץ נתונים ברירת מחדל
-
-def resource_path(filename):
-    """החזרת נתיב לקובץ – עובד גם בפיתוח וגם בתוך EXE"""
-    if hasattr(sys, '_MEIPASS'):
-        return os.path.join(sys._MEIPASS, filename)
-    return os.path.join(os.path.abspath("."), filename)
 
 # ==============================================================================
 #                                 מחלקת האפליקציה הראשית

--- a/hspek/__init__.py
+++ b/hspek/__init__.py
@@ -1,0 +1,1 @@
+"""Hspek package root."""

--- a/hspek/utils/__init__.py
+++ b/hspek/utils/__init__.py
@@ -1,0 +1,1 @@
+"""Utility helpers for Hspek."""

--- a/hspek/utils/paths.py
+++ b/hspek/utils/paths.py
@@ -1,0 +1,8 @@
+import os
+import sys
+
+def resource_path(filename: str) -> str:
+    """Return absolute path to a resource file, compatible with PyInstaller."""
+    if hasattr(sys, '_MEIPASS'):
+        return os.path.join(sys._MEIPASS, filename)
+    return os.path.join(os.path.abspath("."), filename)

--- a/tests/test_pdf_export.py
+++ b/tests/test_pdf_export.py
@@ -4,41 +4,47 @@ from test_torah_tree import load_module
 import shutil
 import os
 import pytest
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from hspek.utils.paths import resource_path
 
 
 def test_write_bookmark_pdf(tmp_path):
     module = load_module()
     tree = {"t": {"פרקים": 1}}
     old_cwd = os.getcwd()
-    os.chdir(tmp_path)
-    repo_root = Path(__file__).resolve().parents[1]
-    map_src = repo_root / "sefaria_masechet_map.json"
-    if map_src.exists():
-        Path(tmp_path / "sefaria_masechet_map.json").write_bytes(map_src.read_bytes())
-    tree_src = repo_root / "torah_tree_data_full.json"
-    if tree_src.exists():
-        Path(tmp_path / "torah_tree_data_full.json").write_bytes(tree_src.read_bytes())
-    tpl_src = repo_root / "bookmark_template.html"
-    if tpl_src.exists():
-        Path(tmp_path / "bookmark_template.html").write_bytes(tpl_src.read_bytes())
-    # Skip if no Chromium/Chrome is available
-    if not (
-        os.environ.get("CHROME_PATH")
-        or shutil.which("chromium-browser")
-        or shutil.which("google-chrome")
-        or shutil.which("chromium")
-        or shutil.which("chrome")
-    ):
-        pytest.skip("Chrome/Chromium not available")
+    map_src = Path(resource_path("sefaria_masechet_map.json"))
+    tree_src = Path(resource_path("torah_tree_data_full.json"))
+    tpl_src = Path(resource_path("bookmark_template.html"))
+    pdf_path = None
+    try:
+        os.chdir(tmp_path)
+        if map_src.exists():
+            Path(tmp_path / "sefaria_masechet_map.json").write_bytes(map_src.read_bytes())
+        if tree_src.exists():
+            Path(tmp_path / "torah_tree_data_full.json").write_bytes(tree_src.read_bytes())
+        if tpl_src.exists():
+            Path(tmp_path / "bookmark_template.html").write_bytes(tpl_src.read_bytes())
+        # Skip if no Chromium/Chrome is available
+        if not (
+            os.environ.get("CHROME_PATH")
+            or shutil.which("chromium-browser")
+            or shutil.which("google-chrome")
+            or shutil.which("chromium")
+            or shutil.which("chrome")
+        ):
+            pytest.skip("Chrome/Chromium not available")
 
-    pdf_path = module.write_bookmark_pdf(
-        titles_list=["t"],
-        mode="פרקים",
-        start_date=date(2024, 1, 1),
-        end_date=date(2024, 1, 1),
-        tree_data=tree,
-        no_study_weekdays_set=set(),
-    )
-    os.chdir(old_cwd)
+        pdf_path = module.write_bookmark_pdf(
+            titles_list=["t"],
+            mode="פרקים",
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 1),
+            tree_data=tree,
+            no_study_weekdays_set=set(),
+        )
+    finally:
+        os.chdir(old_cwd)
     assert pdf_path is not None
     assert Path(pdf_path).exists()

--- a/tests/test_torah_tree.py
+++ b/tests/test_torah_tree.py
@@ -4,9 +4,12 @@ import types
 from pathlib import Path
 import pytest
 
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from hspek.utils.paths import resource_path
+
 
 def load_module():
-    path = Path(__file__).resolve().parents[1] / "torah_logic_full_updated.py"
+    path = Path(resource_path("torah_logic_full_updated.py"))
 
     # Stub external GUI/ICS dependencies so the module can be imported
     if "customtkinter" not in sys.modules:

--- a/torah_logic_full_updated.py
+++ b/torah_logic_full_updated.py
@@ -2,23 +2,17 @@ from datetime import date, timedelta, datetime, time
 from ics import Calendar, Event, DisplayAlarm
 import json
 import os
-import sys
 import re
 from urllib.parse import quote_plus, quote
 
 from pyluach import dates, hebrewcal, parshios
 from jinja2 import Environment, FileSystemLoader
 from collections import defaultdict
+from hspek.utils.paths import resource_path
 
 # כתובת ברירת מחדל לפתיחת חומר הלימוד היומי
 # {ref} מוחלף בהפניה המדויקת בספריא (לדוגמה "בראשית.א-ב")
 DEFAULT_LESSON_LINK = "https://www.sefaria.org.il/he/{ref}"
-
-def resource_path(filename):
-    """החזרת נתיב לקובץ – עובד גם בפיתוח וגם בתוך EXE"""
-    if hasattr(sys, '_MEIPASS'):
-        return os.path.join(sys._MEIPASS, filename)
-    return os.path.join(os.path.abspath("."), filename)
 
 
 # זיהוי קטגוריית התוכן (תנ"ך, משנה או תלמוד) לפי הנתיב המלא של היחידה


### PR DESCRIPTION
## Summary
- extract resource_path into new hspek.utils.paths module
- update torah_logic_full_updated.py and app_gui_full_updated.py to use shared helper
- adjust tests to load resources through new path module

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc77f737fc83259715a0bd55b00482